### PR TITLE
Fix placeholder showing underneath image after loading

### DIFF
--- a/src/ReactImageAppear.js
+++ b/src/ReactImageAppear.js
@@ -86,8 +86,8 @@ class ReactImageAppear extends Component {
 
     parseComputedDimensions(el) {
         return {
-            width: Number(window.getComputedStyle(el).width.match(/\d+/)),
-            height: Number(window.getComputedStyle(el).height.match(/\d+/))
+            width: Number(window.getComputedStyle(el).width.match(/\d+\.?\d+/g).join('')),
+            height: Number(window.getComputedStyle(el).height.match(/\d+\.?\d+/g).join(''))
         };
     }
 

--- a/src/ReactImageAppear.js
+++ b/src/ReactImageAppear.js
@@ -85,9 +85,11 @@ class ReactImageAppear extends Component {
     }
 
     parseComputedDimensions(el) {
+        const widthMatch = window.getComputedStyle(el).width.match(/\d+\.?\d+/g);
+        const heightMatch = window.getComputedStyle(el).height.match(/\d+\.?\d+/g);
         return {
-            width: Number(window.getComputedStyle(el).width.match(/\d+\.?\d+/g).join('')),
-            height: Number(window.getComputedStyle(el).height.match(/\d+\.?\d+/g).join(''))
+            width: widthMatch ? Number(widthMatch.join('')) : undefined,
+            height: heightMatch ? Number(heightMatch.join('')) : undefined,
         };
     }
 


### PR DESCRIPTION
Truncation error results in placeholder image being wider/taller than image, and currently both are shown at the same time in some cases